### PR TITLE
fix login controller responses

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -2,35 +2,36 @@
 const jwt = require('jsonwebtoken');
 const passport = require('../utils/pass');
 const bcryptjs = require('bcryptjs');
-const { body, validationResult } = require('express-validator');
-const User  = require('../models/userModel.js');
-
-require('dotenv').config({ path: '../.env' });
+const { validationResult } = require('express-validator');
+const User = require('../models/userModel.js');
+const { Op } = require('sequelize');
 
 const login = (req, res) => {
-    /* #swagger.parameters['username'] = {in: 'body', example: "password", description: 'The email of the user', type: 'string' } */
-    /* #swagger.parameters['password'] = {in: 'body', description: 'The password of the user', type: 'string' } */ 
+  /* #swagger.parameters['username'] = {in: 'body', example: "password", description: 'The email of the user', type: 'string' } */
+  /* #swagger.parameters['password'] = {in: 'body', description: 'The password of the user', type: 'string' } */
 
-    // Validate login.
-    passport.authenticate('local', { session: false }, (err, user, info) => {
+  // Validate login attempt.
+  passport.authenticate('local', { session: false }, (err, user, info) => {
     if (err || !user) {
       return res.status(400).json({
         message: err,
         user: null,
-        info: info
+        info: info,
       });
     }
 
+    // Generate a signed json web token for succesful login.
+    // Send a response to client with public user data and token.
     req.login(user, { session: false }, err => {
       if (err) next(err);
-      // generate a signed json web token for succesful login.
       const token = jwt.sign({ id: user.dataValues.id }, process.env.JWT_SECRET);
-      return res.json({ 
+      return res.json({
         name: user.dataValues.name,
         email: user.dataValues.email,
         role: user.dataValues.role,
         score: user.dataValues.score,
-        token: token });
+        token: token,
+      });
     });
   })(req, res);
 };
@@ -40,48 +41,65 @@ const logout = (req, res) => {
   res.redirect('/');
 };
 
-const user_create_post = async (req, res, next) => {
+const register_post = async (req, res) => {
   // Extract the validation errors from a request.
-  const errors = validationResult(req); // TODO require validationResult, see userController
+  const validationErrors = validationResult(req);
+  if (!validationErrors.isEmpty()) {
+    console.log('register error', validationErrors);
+    return res.send(validationErrors.array());
+  }
 
-  if (!errors.isEmpty()) {
-    console.log('user create error', errors);
-    return res.send(errors.array());
-  } else {
-    const salt = bcryptjs.genSaltSync(10);
-    const hash = bcryptjs.hashSync(req.body.password, salt);
 
-    const users = await User.findAll({
-      where: {
+  // Check for pre-existing user with same name/email
+  const users = await User.findAll({
+    where: {
+      [Op.or]: { // Single one of these conditions is enough to abort.
         name: req.body.name.toLowerCase(),
-        email: req.body.email.toLowerCase()
+        email: req.body.email.toLowerCase(),
+      },
+    },
+  });
+
+  if (users.length > 0) {
+    const errors = [];
+    users.forEach(usr => {
+      // Check if name collides => add name error. One is enough, please.
+      if (usr.name === req.body.name && !errors.find(err => err.field === 'name')) {
+        errors.push({
+          field: 'name',
+          error: 'User already exists with that username',
+        });
+      }
+      // Check if email collides => add email error. One is enough, please.
+      if (usr.email === req.body.email && !errors.find(err => err.field === 'email')) {
+        errors.push({
+          field: 'email',
+          error: 'User already exists with that email',
+        });
       }
     });
-    console.log("users", users)
-    if(users.length > 0) {
-      return res.status(400).json({errors: ["User already exists with this email"]});
-    } 
+    return res.status(400).json({ errors: errors });
+  }
 
-    const newUser = User.create({
-      name: req.body.name,
-      password: hash,
-      email: req.body.email,
-      role: 0,
-      score: 0,
-    });
+  const salt = bcryptjs.genSaltSync(10);
+  const hash = bcryptjs.hashSync(req.body.password, salt);
+  const newUser = User.create({
+    name: req.body.name,
+    password: hash,
+    email: req.body.email,
+    role: 0,
+    score: 0,
+  });
 
-
-
-    if (newUser) {
-      return res.json({ msg: `User added`});
-    } else {
-      return res.status(400).json({ error: 'register error' });
-    }
+  if (newUser) {
+    return res.json({ msg: `User added` });
+  } else {
+    return res.status(500).json({ error: 'register error' }); // My bad, not user's.
   }
 };
 
 module.exports = {
   login,
   logout,
-  user_create_post,
+  register_post,
 };

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -11,23 +11,26 @@ const login = (req, res) => {
     /* #swagger.parameters['username'] = {in: 'body', example: "password", description: 'The email of the user', type: 'string' } */
     /* #swagger.parameters['password'] = {in: 'body', description: 'The password of the user', type: 'string' } */ 
 
+    // Validate login.
     passport.authenticate('local', { session: false }, (err, user, info) => {
-    console.log(err, user, info);
-
     if (err || !user) {
       return res.status(400).json({
         message: err,
-        user: user,
+        user: null,
+        info: info
       });
     }
 
     req.login(user, { session: false }, err => {
-      if (err) {
-        next(err);
-      }
-      // generate a signed son web token with the contents of user object and return it in the response
-      const token = jwt.sign(user, process.env.JWT_SECRET);
-      return res.json({ user: user, token: token });
+      if (err) next(err);
+      // generate a signed json web token for succesful login.
+      const token = jwt.sign({ id: user.dataValues.id }, process.env.JWT_SECRET);
+      return res.json({ 
+        name: user.dataValues.name,
+        email: user.dataValues.email,
+        role: user.dataValues.role,
+        score: user.dataValues.score,
+        token: token });
     });
   })(req, res);
 };

--- a/routes/authRoute.js
+++ b/routes/authRoute.js
@@ -2,7 +2,7 @@
 const express = require('express');
 const router = express.Router();
 const { body, sanitizeBody } = require('express-validator');
-const { login, logout, user_create_post } = require('../controllers/authController');
+const { login, logout, register_post } = require('../controllers/authController');
 
 router.post('/login', body("username").notEmpty(), login);
 router.get('/logout', logout);
@@ -16,7 +16,7 @@ router.post(
     body("password", "The password needs at least 8 characters").isLength({min: 8}).trim().escape(),
     sanitizeBody('name').escape(),
   ],
-  user_create_post
+  register_post
 );
 
 module.exports = router;


### PR DESCRIPTION
### Improved error messages on `/auth/register`
When both email and username is taken:
```js
{
  "errors": [
    {
      "field": "name",
      "error": "User already exists with that username"
    },
    {
      "field": "email",
      "error": "User already exists with that email"
    }
  ]
}
```

When only email is taken:
```js
{
  "errors": [
    {
      "field": "email",
      "error": "User already exists with that email"
    }
  ]
}
```
And so on...

Returning field names in errors makes it possible to render them in UI to the user.

### Renamed controller `user_create_post` to `register_post`
I thought that this had something to do with posting recipes, so mayhaps this naming is more intuitive.

### Removed outdated comments added more to some places 