### PR TITLE
Fix M2M relation with recipe and ingredient

### DIFF
--- a/controllers/recipeController.js
+++ b/controllers/recipeController.js
@@ -36,7 +36,7 @@ const recipe_get = async (req, res) => {
     where: { id: recipeId },
   });
   console.log('recipeId', recipeId);
-  console.log('recipe', recipe);
+
   if(!recipe) {
     return res.status(400).json({error: "Recipe not found"});
   }

--- a/database/db.js
+++ b/database/db.js
@@ -29,8 +29,8 @@ User.hasMany(Comment, { as: fkName(Comment), foreignKey: 'user_id' });
 User.hasMany(Like, { as: fkName(Like), foreignKey: 'user_id' });
 
 //many-to-many relationship between ingredient and recipe
-Recipe.belongsToMany(Ingredient, {through: RecipeIngredient});
-Ingredient.belongsToMany(Recipe, { through: RecipeIngredient});
+Recipe.belongsToMany(Ingredient, {as: fkName(Ingredient), through: RecipeIngredient});
+Ingredient.belongsToMany(Recipe, {as: fkName(Recipe),  through: RecipeIngredient});
 
 Recipe.hasMany(Picture, { as: fkName(Picture), foreignKey: 'recipe_id' });
 Recipe.hasMany(Step, { as: fkName(Step), foreignKey: 'recipe_id' });
@@ -89,8 +89,8 @@ const sync = async () => {
             name: faker.lorem.word() + ' ' + faker.lorem.word(),
             desc: faker.lorem.sentences().substring(0, 250),
             owner_id: user.id,
-            culinari_ingredients: ingredients,
-          }, {include: Ingredient});
+            ingredient: ingredients,
+          }, {include: [{model: Ingredient, as: fkName(Ingredient)}]});
           console.log("Created ", recipe);
 
           // add pictures

--- a/models/commentModel.js
+++ b/models/commentModel.js
@@ -22,8 +22,9 @@ Comment.init(
       allowNull: false,
     },
   },
-  {
+{
     sequelize,
+    freezeTableName: true,
     modelName: sequelize._TABLE_NAME_PREFIX + 'comment',
   }
 );

--- a/models/ingredientModel.js
+++ b/models/ingredientModel.js
@@ -12,8 +12,9 @@ Ingredient.init(
       allowNull: false,
     }
   },
-  {
+{
     sequelize,
+    freezeTableName: true,
     modelName: sequelize._TABLE_NAME_PREFIX + 'ingredient',
   }
 );

--- a/models/likeModel.js
+++ b/models/likeModel.js
@@ -17,8 +17,9 @@ Like.init(
       allowNull: false,
     },
   },
-  {
+{
     sequelize,
+    freezeTableName: true,
     modelName: sequelize._TABLE_NAME_PREFIX + 'like',
   }
 );

--- a/models/pictureModel.js
+++ b/models/pictureModel.js
@@ -22,8 +22,9 @@ Picture.init(
       allowNull: false,
     },
   },
-  {
+{
     sequelize,
+    freezeTableName: true,
     modelName: sequelize._TABLE_NAME_PREFIX + 'picture',
   }
 );

--- a/models/recipeIngredientModel.js
+++ b/models/recipeIngredientModel.js
@@ -16,8 +16,9 @@ RecipeIngredient.init(
       field: 'unit',
     }
   },
-  {
+{
     sequelize,
+    freezeTableName: true,
     modelName: sequelize._TABLE_NAME_PREFIX + 'recipeIngredient',
   }
 );

--- a/models/stepModel.js
+++ b/models/stepModel.js
@@ -21,8 +21,9 @@ Step.init(
       allowNull: false,
     },
   },
-  {
+{
     sequelize,
+    freezeTableName: true,
     modelName: sequelize._TABLE_NAME_PREFIX + 'step',
   }
 );

--- a/models/userModel.js
+++ b/models/userModel.js
@@ -1,4 +1,4 @@
-'use strict';
+  'use strict';
 const { Sequelize, Model } = require('sequelize');
 const sequelize = require('../database/sequelize_init.js');
 
@@ -36,8 +36,9 @@ User.init(
       allowNull: false,
     },
   },
-  {
+{
     sequelize,
+    freezeTableName: true,
     modelName: sequelize._TABLE_NAME_PREFIX + 'user',
     defaultScope: {
       attributes: { exclude: ['password', 'updatedAt', 'createdAt'] },

--- a/utils/fkName.js
+++ b/utils/fkName.js
@@ -2,6 +2,7 @@
 const fkName = model => {
   const splitName = model.getTableName().split('_');
   const name = splitName[splitName.length - 1];
+  console.log(`fkname ${model.getTableName()}\t${name}`);
   return name;
 };
 


### PR DESCRIPTION
* Fix table names
* Override Recipe-model's `toJSON`-method

### Example of flattened Recipe json
```
{
    "id": 1,
    "name": "vero ut",
    "desc": "Nulla iusto autem labore aut et. Modi hic aut inventore sed occaecati tempora. Quia ut nostrum esse est porro ipsum doloribus. Quibusdam delectus consectetur. Consectetur consequatur est reprehenderit ad. Ab totam aperiam.",
    "owner_id": 2,
    "forked_from": null,
    "createdAt": "2021-12-13T18:34:36.000Z",
    "updatedAt": "2021-12-13T18:34:36.000Z",
    "picture": [
        {
            "id": 1,
            "recipe_id": 1,
            "filename": "photo_2021-12-03_14-28-59.png",
            "order": 0
        },
        ...
    ],
    "ingredient": [
        {
            "amount": 1,
            "unit": "kpl",
            "createdAt": "2021-12-13T18:34:36.000Z",
            "updatedAt": "2021-12-13T18:34:36.000Z",
            "culinariRecipeId": 1,
            "culinariIngredientId": 1
        },
        ...
    ],
    "step": [
        {
            "id": 1,
            "content": "Asperiores nisi illo sed. Autem incidunt aut in quis veniam tempora voluptatem et.",
            "order": 0
        },
        ...
    ]
}
```